### PR TITLE
feat: 다중 페이지 후보풀 캐시로 랜덤성/성능 개선

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 - Persisted today's completion into `dailyState.history` immediately when solved check succeeds
 - Hardened streak computation to honor history-based completion for today
 - Replaced raw handle validation errors with user-friendly messages for not found, network, and rate limit cases
+- Added multi-page candidate pool fetching (1..5) with criteria-based cache reuse and stale fallback
 
 ## [1.0.0] - 2026-02-23
 - Initial extension release


### PR DESCRIPTION
## Summary
- 문제 선택 로직을 `page=1` 단일 조회에서 `page=1..5` 다중 페이지 후보풀 수집 방식으로 개선했습니다.
- 선택 기준(query) 기반 후보풀 캐시를 도입해, 동일 조건에서는 API 재호출 없이 후보풀을 재사용하도록 최적화했습니다.
- 네트워크/일부 페이지 오류 상황에서도 가능한 범위에서 동작하도록 부분 실패 허용 및 stale fallback을 추가했습니다.

## Related Issue
- Closes #3 

## Type of Change
- [x] feat (new feature)
- [ ] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] docs (documentation)
- [ ] chore (build/config/maintenance)

## Why
- 기존에는 `search/problem`의 첫 페이지만 사용해 랜덤성이 낮고 특정 문제군으로 편향되는 문제가 있었습니다.
- reroll 시 매번 API를 재조회하면 불필요한 호출 비용이 커질 수 있어, 동일 조건 후보풀 재사용 최적화가 필요했습니다.

## What Changed
- `src/background/sw.js`
  - `CANDIDATE_POOL_PAGE_COUNT=5`, `CANDIDATE_POOL_TTL_MS=6h` 도입
  - 후보풀 키(`query + pageCount`) 생성 및 유효성 검사 로직 추가
  - 다중 페이지 수집(`1..5`), 문제 ID 중복 제거, 부분 실패 허용
  - 캐시 재사용/TTL 만료 재수집/stale fallback 로직 추가
  - `ensureDailyState`, `rerollToday`, `resetToday` 경로를 새 후보풀 로직으로 연결
- `src/shared/storage.js`
  - `dailyState` 확장:
    - `candidatePoolKey`
    - `candidatePoolUpdatedAt`
    - `candidatePool`
  - 후보풀 정규화/중복 제거/크기 제한(`MAX_CANDIDATE_POOL=500`) 추가
- `docs/CHANGELOG.md`
  - 1.0.1 변경사항에 다중 페이지 후보풀 캐시 도입 내용 추가

## Impact Scope
- [ ] popup
- [ ] options
- [x] background/service worker
- [ ] redirect/locking logic
- [x] storage/state
- [x] docs

## Risk & Rollback Plan
- Risk:
  - 후보풀 캐시 키 설계 누락 시 잘못된 재사용 가능성
  - TTL 설정이 부적절하면 최신성/호출량 트레이드오프 발생
  - 부분 실패 허용 로직에서 극단 케이스(연속 API 장애) 점검 필요
- Rollback:
  - 본 PR revert 시 기존 단일 페이지 선택 로직으로 즉시 복귀 가능

## How to Test
1. 기본 동작/캐시 재사용
   - `GET_SNAPSHOT`으로 최초 문제 선택 후 API 호출 수 확인
   - `REROLL` 실행 시 동일 조건에서 추가 페이지 fetch가 발생하지 않는지 확인
2. 조건 변경/무효화
   - 옵션에서 필터(예: `minSolvedCount`) 변경 후 `SAVE_SETTINGS`
   - 새 query 기준으로 후보풀이 재수집되는지 확인
3. 실패 경계값
   - 일부 페이지 실패(예: page2 오류, page1/3 성공) 시 문제 선택이 계속 되는지 확인
   - 전체 실패 시 동일 query 캐시가 있으면 fallback 되는지 확인
   - 후보 0개면 `lastApiError=no_candidates`로 처리되는지 확인

### Mock Boundary Test Results
- `TC01_page1_only`: PASS
- `TC02_cache_reuse_on_reroll`: PASS
- `TC03_invalidate_on_filter_change`: PASS
- `TC04_partial_failure_still_usable`: PASS
- `TC05_stale_fallback_when_all_fail`: PASS
- `TC06_no_candidates_error`: PASS
- `TC07_ttl_expired_refetch`: PASS
- `TC08_dedupe_candidate_ids`: PASS
- Summary: `passed=8 failed=0`

## Checklist
- [x] 이 PR만으로 리뷰 가능하도록 설명/맥락을 작성함
- [x] 관련 문서(README/CHANGELOG 등) 업데이트 여부를 확인함
- [x] 로컬에서 수동 테스트를 완료함
- [x] 브레이킹 체인지 여부를 확인함

## Release Note (for maintainers)
- 다중 페이지(1~5) 후보 수집으로 문제 랜덤성 향상
- 선택 기준 기반 후보풀 캐시 재사용으로 reroll 성능 개선
- 부분 API 실패/전체 실패 시 fallback 경로 추가로 안정성 강화

## Screenshots (optional)
- 없음