### PR TITLE
chore: v1.0.1 릴리즈 - 버전/변경로그 날짜 반영

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [1.0.1] - Unreleased
+## [1.0.1] - 2026-02-23
 - Fixed reroll flow to preserve cleared state/history instead of dropping today's completion record
 - Persisted today's completion into `dailyState.history` immediately when solved check succeeds
 - Hardened streak computation to honor history-based completion for today

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "BOJ Forcer",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Force yourself to solve one BOJ problem daily before browsing freely.",
   "permissions": ["storage", "tabs"],
   "host_permissions": ["https://solved.ac/*", "https://www.acmicpc.net/*"],


### PR DESCRIPTION
## Summary
- v1.0.1 릴리즈 준비를 위해 확장 버전과 변경로그 날짜를 확정했습니다.

## Type of Change
- [ ] feat (new feature)
- [ ] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] docs (documentation)
- [x] chore (build/config/maintenance)

## Why
- 릴리즈 태깅/배포 전에 실제 배포 버전(`manifest.json`)과 CHANGELOG 릴리즈 날짜를 고정해야 합니다.

## What Changed
- `manifest.json`
  - `version`: `1.0.0` → `1.0.1`
- `docs/CHANGELOG.md`
  - `## [1.0.1] - Unreleased` → `## [1.0.1] - 2026-02-23`

## Impact Scope
- [ ] popup
- [ ] options
- [ ] background/service worker
- [ ] redirect/locking logic
- [ ] storage/state
- [x] docs

## Risk & Rollback Plan
- Risk:
  - 버전 문자열/날짜 표기 변경만 포함되어 기능 리스크는 매우 낮음
- Rollback:
  - 본 PR revert 시 이전 상태(`1.0.0`, `Unreleased`)로 즉시 복구 가능

## How to Test
1. `manifest.json`의 버전이 `1.0.1`인지 확인한다.
2. `docs/CHANGELOG.md`에서 `1.0.1` 항목 날짜가 `2026-02-23`인지 확인한다.
3. 변경 파일이 위 2개만 포함되었는지 PR diff를 확인한다.

## Checklist
- [x] 관련 문서(README/CHANGELOG 등) 업데이트 여부를 확인함
- [x] 로컬에서 수동 테스트를 완료함
- [x] 브레이킹 체인지 여부를 확인함

## Release Note (for maintainers)
- v1.0.1 릴리즈 메타데이터 확정
- manifest 버전 1.0.1 반영
- CHANGELOG 1.0.1 릴리즈 날짜 반영

## Screenshots (optional)
- 없음
