### PR TITLE
feat: 클리어 직후 자동 다음 문제 세팅 및 day-level 완료 상태 분리

### DIFF
--- a/src/shared/picker.js
+++ b/src/shared/picker.js
@@ -84,12 +84,12 @@ function hashString(input) {
   return (h >>> 0) || 1;
 }
 
-export function pickDeterministicProblemId(candidates, dateKST, rerollUsed = 0) {
+export function pickDeterministicProblemId(candidates, dateKST, rerollUsed = 0, autoAdvanceUsed = 0) {
   const list = Array.from(new Set((Array.isArray(candidates) ? candidates : []).map((v) => Number(v))))
     .filter((v) => Number.isInteger(v) && v > 0)
     .sort((a, b) => a - b);
   if (!list.length) return 0;
-  const seed = `${dateKST}:${rerollUsed}`;
+  const seed = `${dateKST}:${rerollUsed}:${autoAdvanceUsed}`;
   const idx = hashString(seed) % list.length;
   return list[idx];
 }


### PR DESCRIPTION
## Summary
- 클리어 직후 다음 랜덤 문제를 자동 세팅하도록 변경
- day-level 완료 상태와 current problem 완료 상태를 분리
- 자동 next는 일일 변경 횟수(rerollUsed)를 차감하지 않도록 처리

## Related Issue
- Closes #8 

## Type of Change
- [x] feat (new feature)
- [ ] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] docs (documentation)
- [ ] chore (build/config/maintenance)

## Why
- 기존에는 클리어 이후 화면/문제가 그대로 유지되어 흐름이 끊겼고,
  "오늘 완료 여부"와 "현재 문제 완료 여부"가 같은 상태값으로 묶여 있어 UX 확장 시 충돌 가능성이 있었음.

## What Changed
- `dailyState` 확장
  - `doneToday` 추가 (day-level 완료)
  - `currentProblemSolved` 추가 (현재 문제 완료)
  - `autoAdvanceUsed` 추가 (자동 next seed 분리용)
- solved check 성공 시 동작 변경
  1. history 저장
  2. `doneToday=true` 갱신
  3. 다음 문제 자동 선정 후 `todayProblemId` 즉시 교체
- 자동 next는 `rerollUsed` 미차감
- deterministic picker seed 확장
  - `dateKST + rerollUsed + autoAdvanceUsed`
- snapshot에 `dayCompleted`, `currentProblemStatus` 추가

## Impact Scope
- [ ] popup
- [ ] options
- [x] background/service worker
- [x] redirect/locking logic
- [x] storage/state
- [ ] docs

## Risk & Rollback Plan
- Risk:
  - 상태 분리로 인해 기존 `solved` 단일 상태를 참조하던 흐름에서 회귀 가능성
  - 자동 next 후보군이 매우 작을 때 동일 문제 재선정 가능성
- Rollback:
  - 본 PR 커밋 revert 시 기존 `solved` 단일 상태 흐름으로 즉시 복귀 가능
  - 필요 시 `performSolvedCheck` 내 auto-next 블록만 제거해 부분 롤백 가능

## How to Test
1. 미완료 상태에서 `Check`를 눌러 정답 처리된 문제를 감지시킨다.
2. 감지 직후 `history`가 유지되고 `todayProblemId`가 다음 문제로 자동 교체되는지 확인한다.
3. 자동 교체 이후 `rerollUsed`가 증가하지 않는지, 강제 리다이렉트가 day-level 완료 기준으로 해제되는지 확인한다.

## Checklist
- [x] 이 PR만으로 리뷰 가능하도록 설명/맥락을 작성함
- [x] 관련 문서(README/CHANGELOG 등) 업데이트 여부를 확인함
- [x] 로컬에서 수동 테스트를 완료함
- [x] 브레이킹 체인지 여부를 확인함

## Release Note (for maintainers)
- 클리어 시 다음 문제 자동 세팅 도입
- day-level 완료 상태(`doneToday`)와 현재 문제 상태(`currentProblemSolved`) 분리
- 자동 next는 일일 reroll 카운트 미차감

## Screenshots (optional)
- N/A
