### PR TITLE
feat: 태그 필터 UX 고도화 + change panel 기본 닫힘

### DIFF
--- a/src/options/options.html
+++ b/src/options/options.html
@@ -70,7 +70,19 @@
 
         <p id="lblTags" class="label">Problem Tags</p>
         <p id="hintTags" class="hint"></p>
-        <div id="tagList" class="tagGrid"></div>
+        <div class="tagToolbar">
+          <input id="tagSearch" class="field mono tagSearchInput" placeholder="Search tags" />
+          <div class="tagActionRow">
+            <button id="btnTagSelectAll" class="btn tagActionBtn" type="button">Select All</button>
+            <button id="btnTagClearAll" class="btn tagActionBtn" type="button">Clear All</button>
+          </div>
+        </div>
+        <p id="tagModeHint" class="hint"></p>
+        <div id="tagList" class="tagGrid isCollapsed"></div>
+        <div class="tagExpandRow">
+          <button id="btnTagExpand" class="btn tagExpandBtn" type="button">Show More</button>
+        </div>
+        <p id="tagSearchEmpty" class="hint tagSearchEmpty isHidden">No tags match your search.</p>
       </section>
 
       <section class="card section">

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -1,4 +1,4 @@
-<!doctype html>
+﻿<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
@@ -39,8 +39,8 @@
 
         <section class="changeBlock">
           <div class="changeHeaderRow">
-            <button id="btnChangeToggle" type="button" class="changeToggleBtn" aria-expanded="true">
-              <span id="changeCaret" class="changeCaret">▼</span>
+            <button id="btnChangeToggle" type="button" class="changeToggleBtn" aria-expanded="false">
+              <span id="changeCaret" class="changeCaret">&#9654;</span>
               <span id="txtChangeHeader">Change Today's Problem (0 / 0)</span>
             </button>
             <button id="btnChangeHelp" type="button" class="changeHelpBtn" aria-label="Change help">?</button>
@@ -87,3 +87,4 @@
     <script type="module" src="popup.js"></script>
   </body>
 </html>
+

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -108,7 +108,7 @@ let latestSnapshot = null;
 let recheckLoading = false;
 let popupSessionOpened = false;
 let popupSessionClosedNotified = false;
-let changePanelOpen = true;
+let changePanelOpen = false;
 let changeMode = "random";
 
 function t(locale, key) {
@@ -402,7 +402,7 @@ els.btnOptions.addEventListener("click", () => {
 });
 
 setChangeMode("random");
-setChangePanelOpen(true);
+setChangePanelOpen(false);
 refresh(true).catch((err) => {
   // eslint-disable-next-line no-console
   console.error(err);

--- a/src/shared/picker.js
+++ b/src/shared/picker.js
@@ -1,6 +1,13 @@
 const TIER_NAMES = ["Bronze", "Silver", "Gold", "Platinum", "Diamond", "Ruby"];
 const TIER_ROMAN = ["V", "IV", "III", "II", "I"];
 
+function normalizeTagKey(rawTag) {
+  const tag = String(rawTag || "").trim().toLowerCase();
+  if (!tag) return "";
+  if (tag === "tree") return "trees";
+  return tag;
+}
+
 function tierNameByLevel(level) {
   const n = Math.max(1, Math.min(30, Number(level) || 1));
   const tierIndex = Math.floor((n - 1) / 5);
@@ -24,7 +31,7 @@ export function normalizeTagList(input) {
   const seen = new Set();
   const out = [];
   for (const raw of String(input || "").split(/\s|,|\n/)) {
-    const tag = raw.trim().toLowerCase();
+    const tag = normalizeTagKey(raw);
     if (!tag || seen.has(tag)) continue;
     seen.add(tag);
     out.push(tag);
@@ -62,12 +69,12 @@ export function buildProblemQuery(settings) {
   if (minSolvedCount > 0) tokens.push(`s#${Math.floor(minSolvedCount)}..`);
 
   for (const tag of includeTags) {
-    const t = String(tag || "").trim().toLowerCase();
+    const t = normalizeTagKey(tag);
     if (!t) continue;
     tokens.push(`#${t}`);
   }
   for (const tag of excludeTags) {
-    const t = String(tag || "").trim().toLowerCase();
+    const t = normalizeTagKey(tag);
     if (!t) continue;
     tokens.push(`!#${t}`);
   }

--- a/src/shared/storage.js
+++ b/src/shared/storage.js
@@ -28,6 +28,7 @@ export const DEFAULT_SETTINGS = Object.freeze({
     requireSolvable: true,
     excludeWarnings: true,
     minSolvedCount: 1,
+    tagSelectionBase: "all",
     includeTags: [],
     excludeTags: []
   },
@@ -87,7 +88,8 @@ function cleanTagList(tags) {
   const out = [];
   const seen = new Set();
   for (const raw of asArray(tags)) {
-    const tag = String(raw || "").trim().toLowerCase();
+    const original = String(raw || "").trim().toLowerCase();
+    const tag = original === "tree" ? "trees" : original;
     if (!tag || seen.has(tag)) continue;
     seen.add(tag);
     out.push(tag);
@@ -121,6 +123,7 @@ function normalizeFilters(filters) {
     requireSolvable: Boolean(merged.requireSolvable),
     excludeWarnings: Boolean(merged.excludeWarnings),
     minSolvedCount: clampNumber(merged.minSolvedCount, 1, 1_000_000, DEFAULT_SETTINGS.filters.minSolvedCount),
+    tagSelectionBase: merged.tagSelectionBase === "none" ? "none" : "all",
     includeTags: cleanTagList(merged.includeTags),
     excludeTags: cleanTagList(merged.excludeTags)
   };

--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -419,6 +419,42 @@ select.field option{
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(210px, 1fr));
   gap: 8px;
+  transition: max-height .18s ease;
+}
+.tagGrid.isCollapsed{
+  overflow: hidden;
+}
+.tagToolbar{
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+}
+.tagSearchInput{
+  flex: 1;
+}
+.tagActionRow{
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+  min-width: 240px;
+}
+.tagActionBtn{
+  width: 100%;
+  min-width: 110px;
+  padding-inline: 12px;
+}
+.tagModeHint{
+  margin-top: -2px;
+}
+.tagExpandRow{
+  display: flex;
+  justify-content: flex-end;
+}
+.tagExpandBtn{
+  width: auto;
+  min-width: 120px;
+  max-width: 160px;
+  padding-inline: 14px;
 }
 .tagItem{
   display: flex;
@@ -433,6 +469,37 @@ select.field option{
 }
 .tagItem input{
   margin: 0;
+}
+.tagItem.isHidden{
+  display: none;
+}
+.tagItem.isCollapsedHidden{
+  display: none;
+}
+.tagSearchEmpty{
+  margin-top: 2px;
+}
+.isHidden{
+  display: none !important;
+}
+@media (max-width: 620px){
+  .tagToolbar{
+    flex-direction: column;
+    align-items: stretch;
+  }
+  .tagActionRow{
+    min-width: 0;
+  }
+  .tagActionBtn{
+    width: 100%;
+  }
+  .tagExpandRow{
+    justify-content: stretch;
+  }
+  .tagExpandBtn{
+    width: 100%;
+    max-width: none;
+  }
 }
 
 .mono{


### PR DESCRIPTION
## Summary
- #13 범위로 태그 필터 UX/데이터 모델을 개편하고, popup의 Change Today’s Problem 패널 기본 상태를 닫힘으로 변경함.
- 태그 검색/선택 흐름은 유지하면서 기본 노출량을 제어해 옵션 가독성을 개선함.

## Related Issue
- Closes #13 

## Type of Change
- [x] feat (new feature)
- [x] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] docs (documentation)
- [ ] chore (build/config/maintenance)

## Why
- solved.ac 태그 수가 많아 기존 정적 목록/전체 노출 방식은 설정 화면 가독성과 사용성이 떨어졌음.
- `tree`/`trees` 키 불일치로 필터 결과가 왜곡될 위험이 있었음.
- Change Today’s Problem 패널 기본 열림 상태가 메인 루프 CTA 집중도를 떨어뜨렸음.

## What Changed
- options 태그 필터 UI
- 태그 검색 입력 유지 (문자 매칭 검색)
- `Select All` / `Clear All` 버튼을 동일 레벨로 나란히 배치
- 기본 상태에서 `Show More` 전 최대 60개만 노출
- `Show More / Show Less` 토글 추가
- options 태그 데이터 소스/캐시
- solved.ac `tag/list` 결과를 로컬 캐시(`chrome.storage.local`)에 저장
- 캐시 갱신 주기: 7일 TTL
- 갱신 실패 시 기존 캐시/정적 fallback 유지 + 재시도 백오프 적용
- 태그 모델/정합성
- `filters.tagSelectionBase`(`all`/`none`) 도입
- `tree -> trees` 정규화 적용 (options/storage/picker/api 파이프라인)
- legacy 설정값도 자동 호환
- popup UX
- Change Today’s Problem 패널 기본값을 닫힘으로 변경 (caret/aria 상태 포함)

## Impact Scope
- [x] popup
- [x] options
- [ ] background/service worker
- [ ] redirect/locking logic
- [x] storage/state
- [ ] docs

## Risk & Rollback Plan
- Risk:
- 태그 목록이 최대 7일 캐시 기준으로 유지되어 최신 태그 반영이 즉시 되지 않을 수 있음.
- Rollback:
- 문제 발생 시 커밋 `5afba89` revert로 이전 동작 복구 가능.

## How to Test
1. popup 열기: `Change Today’s Problem`이 기본 닫힘(▶, `aria-expanded=false`)인지 확인.
2. options > Problem Tags 진입: 초기 노출이 최대 60개인지 확인.
3. `Show More` 클릭 시 전체 목록 노출, `Show Less` 클릭 시 다시 60개로 접히는지 확인.
4. 태그 검색 입력 시 매칭된 항목만 표시되는지 확인.
5. `Select All` / `Clear All` 클릭 시 모드/카운트가 즉시 반영되는지 확인.
6. 저장 후 options 재진입 시 선택 상태(`tagSelectionBase`, include/exclude)가 유지되는지 확인.
7. 기존 `tree` 설정이 있어도 실제 쿼리/저장에서 `trees`로 정규화되는지 확인.
8. 네트워크 실패 상황에서 캐시/정적 fallback으로 태그 목록이 계속 보이는지 확인.

## Checklist
- [x] 이 PR만으로 리뷰 가능하도록 설명/맥락을 작성함
- [ ] 관련 문서(README/CHANGELOG 등) 업데이트 여부를 확인함
- [ ] 로컬에서 수동 테스트를 완료함
- [x] 브레이킹 체인지 여부를 확인함

## Release Note (for maintainers)
- 옵션 태그 필터가 검색 기반 + 기본 60개 접힘(Show More) 구조로 개선됨.
- solved.ac 태그 목록을 7일 주기로 캐시 갱신하도록 변경됨.
- `tree` 레거시 키를 `trees`로 자동 정규화함.
- popup의 Change Today’s Problem 패널이 기본 닫힘으로 시작함.

## Screenshots (optional)

