### PR TITLE
chore(release): v1.1.0 문서 정리 + version bump

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ BOJ 문제를 하루 1개 강제로 풀게 만드는 Chrome 확장 프로그램�
 
 English subtitle: **Random BOJ Problem Picker & Focus Enforcer**
 
+현재 버전: **v1.1.0**
+
 ## 설치 (일반 사용자)
 Chrome 웹스토어에서 설치하는 것을 권장합니다.
 
@@ -26,8 +28,11 @@ Chrome 웹스토어에서 설치하는 것을 권장합니다.
 ## 핵심 기능
 - solved.ac 필터 기반 오늘의 문제 자동 선정
 - 미해결 상태에서 비허용 사이트 접근 시 문제 페이지로 리다이렉트
+- 클리어 시 기록 보존 + 다음 랜덤 문제 자동 세팅(연속 풀이 흐름)
+- Check 시스템 고도화(팝업 즉시 검사, 활성 상태 1분 폴링, 중복 호출 방지)
+- 오늘 문제 변경(Random Pick / Problem Number) + 공용 일일 변경 카운트
+- 옵션 페이지 태그 UX 개선(검색, Select All/Clear All, Show More/Show Less)
 - 일일 Reroll 제한, Emergency 시간, 자동 검사
-- 옵션 페이지에서 티어/언어/태그/화이트리스트 설정
 
 ## 아키텍처 요약
 - `manifest.json`: MV3 확장 설정

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.1.0] - 2026-02-25
+- Added day-level completion split (`doneToday`) and preserved clear history while auto-advancing to the next random problem after solve
+- Upgraded Check flow: popup-open immediate check, active-state 1 minute polling, and 15 second duplicate check guard
+- Renamed UI term from Re-check to Check
+- Added Change Today's Problem flow: Random Pick + Problem Number with shared daily change budget
+- Added options tag filtering UX: search, Select All/Clear All, default collapsed list with Show More/Show Less, and restored selection state
+- Added solved.ac tag catalog caching (weekly refresh + fallback) and normalized legacy tag key mismatch (`tree` -> `trees`)
+- Changed popup Change section default state to collapsed
+- Improved handle validation flow to save nickname only after explicit Check and apply user tier-based default range (`±5`)
+
 ## [1.0.1] - 2026-02-23
 - Fixed reroll flow to preserve cleared state/history instead of dropping today's completion record
 - Persisted today's completion into `dailyState.history` immediately when solved check succeeds

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "BOJ Forcer",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Force yourself to solve one BOJ problem daily before browsing freely.",
   "permissions": ["storage", "tabs"],
   "host_permissions": ["https://solved.ac/*", "https://www.acmicpc.net/*"],


### PR DESCRIPTION
## Summary
- v1.1.0 릴리즈를 위해 버전/문서를 정리함.
- `manifest.json` 버전을 `1.1.0`으로 상향함.
- `docs/CHANGELOG.md`에 `1.1.0` 변경사항을 추가함.
- `README.md`에 현재 버전 및 핵심 기능 요약을 업데이트함.

## Related Issue
- N/A (release housekeeping)

## Type of Change
- [ ] feat (new feature)
- [ ] fix (bug fix)
- [ ] refactor (no behavior change)
- [x] docs (documentation)
- [x] chore (build/config/maintenance)

## Why
- v1.1.0 배포 전, 실제 반영된 기능 기준으로 버전/문서 싱크를 맞추기 위함.

## What Changed
- `manifest.json`: `version` `1.0.1 -> 1.1.0`
- `docs/CHANGELOG.md`: `1.1.0 (2026-02-25)` 섹션 추가
- `README.md`: 현재 버전 표기 및 v1.1.0 핵심 기능 항목 보강

## Impact Scope
- [ ] popup
- [ ] options
- [ ] background/service worker
- [ ] redirect/locking logic
- [ ] storage/state
- [x] docs

## Risk & Rollback Plan
- Risk:
- 낮음. 런타임 로직 변경 없이 버전/문서만 변경.
- Rollback:
- 본 PR 커밋 revert 시 즉시 복구 가능.

## How to Test
1. `manifest.json`의 버전이 `1.1.0`인지 확인.
2. `docs/CHANGELOG.md`에 `1.1.0` 섹션이 최신 항목으로 추가되었는지 확인.
3. `README.md`의 현재 버전/핵심 기능 설명이 v1.1.0 기준인지 확인.

## Checklist
- [x] 이 PR만으로 리뷰 가능하도록 설명/맥락을 작성함
- [x] 관련 문서(README/CHANGELOG 등) 업데이트 여부를 확인함
- [ ] 로컬에서 수동 테스트를 완료함
- [x] 브레이킹 체인지 여부를 확인함

## Release Note (for maintainers)
- BOJ Forcer v1.1.0 릴리즈 메타 정리 PR
- manifest 버전 상향 및 changelog/readme 최신화

## Screenshots (optional)
