### PR TITLE
20 bug 문제번호 직접 선택 경로에서 과거 풀이 문제 재제출 시 오늘 완료 처리됨

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.1.1] - 2026-03-01
+- Fixed completion check to require an AC submission on BOJ status for the current KST date
+- Prevented previously solved problems from being counted as today's completion when selected by problem number
+- Kept same-day re-submission behavior valid: re-submitting a problem solved today still counts for 1 DAY 1 BOJ
+
 ## [1.1.0] - 2026-02-25
 - Added day-level completion split (`doneToday`) and preserved clear history while auto-advancing to the next random problem after solve
 - Upgraded Check flow: popup-open immediate check, active-state 1 minute polling, and 15 second duplicate check guard

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "BOJ Forcer",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Force yourself to solve one BOJ problem daily before browsing freely.",
   "permissions": ["storage", "tabs"],
   "host_permissions": ["https://solved.ac/*", "https://www.acmicpc.net/*"],

--- a/src/background/sw.js
+++ b/src/background/sw.js
@@ -16,7 +16,7 @@ import { buildProblemQuery, pickDeterministicProblemId, getTodayProblemUrl, isTo
 import {
   searchProblem,
   extractProblemCandidates,
-  checkSolved,
+  checkSolvedToday,
   checkHandle,
   classifyError,
   getProblemById
@@ -425,7 +425,7 @@ async function performSolvedCheck(trigger = "manual") {
     if (waitMs > 0) return { ok: false, reason: "too_recent", waitMs };
 
     const solvedProblemId = daily.todayProblemId;
-    const solved = await checkSolved(settings.handle, solvedProblemId);
+    const solved = await checkSolvedToday(settings.handle, solvedProblemId, todayDateKST);
     daily.lastSolvedCheckAt = now();
     if (solved) {
       setDayCompleted(daily, true);


### PR DESCRIPTION
## Summary
- 문제번호 직접 선택 경로에서 과거에 풀었던 문제를 재제출하면 오늘 완료 처리되던 버그를 수정했습니다.
- 완료 판정을 "과거 solved 여부"가 아닌 "오늘(KST) AC 제출 여부" 기준으로 변경했습니다.
- 릴리즈 패치 버전 `v1.1.1`로 버전업하고 changelog를 업데이트했습니다.

## Related Issue
- Closes #20 

## Type of Change
- [ ] feat (new feature)
- [x] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] docs (documentation)
- [x] chore (build/config/maintenance)

## Why
- 랜덤 선택 흐름에서는 이미 풀이한 문제가 기본적으로 제외되지만, 문제번호 직접 선택 기능 도입 이후 과거 풀이 문제를 통한 완료 우회 가능성이 생겼습니다.
- 1 DAY 1 BOJ 강제성 유지를 위해 "오늘 제출 기반" 완료 판정이 필요했습니다.

## What Changed
- `src/shared/solvedac-api.js`
  - `checkSolvedToday(handle, problemId, todayDateKST)` 추가
  - BOJ status(`problem_id`, `user_id`, `result_id=4`)에서 최신 AC 제출 시각(`data-timestamp`) 파싱 후 오늘(KST) 여부 판정
- `src/background/sw.js`
  - `performSolvedCheck`에서 `checkSolved` -> `checkSolvedToday`로 교체
- `manifest.json`
  - 버전 `1.1.0` -> `1.1.1`
- `docs/CHANGELOG.md`
  - `1.1.1` 릴리즈 노트 추가

## Impact Scope
- [ ] popup
- [ ] options
- [x] background/service worker
- [ ] redirect/locking logic
- [ ] storage/state
- [x] docs

## Risk & Rollback Plan
- Risk:
  - BOJ status HTML 구조(`data-timestamp`)가 변경되면 판정 로직이 영향받을 수 있습니다.
- Rollback:
  - 문제 발생 시 `fix` 커밋(`b6ded36`) revert로 기존 solved.ac 기반 판정으로 즉시 복귀 가능합니다.
  - 릴리즈 메타만 되돌릴 경우 `chore` 커밋(`eda4446`)만 별도 revert 가능합니다.

## How to Test
1. 문제번호 직접 선택으로 "과거에 이미 AC 받은 문제"를 오늘 문제로 설정합니다.
2. 해당 문제를 다시 제출(AC) 후 Check를 실행합니다.
3. 오늘(KST) AC 제출이 없던 경우 완료 처리되지 않는지 확인합니다.
4. 오늘 새로 AC 받은 문제(또는 오늘 AC가 있는 문제)를 Check 했을 때 완료 처리되는지 확인합니다.
5. 오늘 이미 푼 문제를 오늘 재제출한 경우 완료로 인정되는지 확인합니다.

## Checklist
- [x] 이 PR만으로 리뷰 가능하도록 설명/맥락을 작성함
- [x] 관련 문서(README/CHANGELOG 등) 업데이트 여부를 확인함
- [ ] 로컬에서 수동 테스트를 완료함
- [x] 브레이킹 체인지 여부를 확인함

## Release Note (for maintainers)
- Fix: 문제번호 직접 선택 경로에서 과거 풀이 문제 재제출 시 오늘 완료 처리되던 버그 수정
- Change: 완료 판정을 BOJ status 기반 "오늘(KST) AC 제출 여부"로 강화
- Release: v1.1.1

## Screenshots (optional)
